### PR TITLE
Automatically find cartridges and provide checkbox for selecting & masking of password field in options view.

### DIFF
--- a/lib/Debugger.js
+++ b/lib/Debugger.js
@@ -16,9 +16,8 @@ function getRelativePath(fileName) {
         return '';
     }
 
-    if (options.cartridges && options.cartridges.trim().length) {
+    if (options.cartridges && options.cartridges.length) {
         let cartPath = options.cartridges
-            .split('\n')
             .map(str => str.trim())
             .find((path) => fileName.indexOf(path) !== -1);
 
@@ -39,9 +38,8 @@ function mapDwPathToProject(dwPath) {
     const workspacePath = atom.project.getPaths()[0];
     let newPath = dwPath.split('/').join(path.sep);
 
-    if (options.cartridges && options.cartridges.trim().length) {
+    if (options.cartridges && options.cartridges.length) {
         let cartPath = options.cartridges
-            .split('\n')
             .map(str => str.trim())
             .find((cartridge) => dwPath.indexOf(cartridge.split(path.sep).pop()) !== -1);
 

--- a/lib/OptionsView.js
+++ b/lib/OptionsView.js
@@ -205,7 +205,7 @@ export default class OptionsView {
                     if (child.isDirectory() && this.isCartridge(child)
                         && !this.cartridges.all.includes(rpath + name)) {
                         this.createCartridgeCheckbox(child, rpath);
-                    } else if (child.isDirectory() && !this.isCartridge(child)) {
+                    } else if (child.isDirectory() && !this.isCartridge(child) && name !== '.api') {
                         this.checkChildDirectory(child, rpath + name);
                     }
                 });

--- a/lib/OptionsView.js
+++ b/lib/OptionsView.js
@@ -18,127 +18,143 @@ export default class OptionsView {
         };
         this.el =
         <div class="b-bart-options">
+            <div class="bart-tabscontainer">
+                <span class="bart__tabs bart__tabs--active bart-webdav__tab" onclick={this.selectTab.bind(this)}>WebDav Settings</span>
+                <span class="bart__tabs bart-cartridges__tab" onclick={this.selectTab.bind(this)}>Project Cartridges</span>
+                <span class="bart__tabs bart-folders__tab" onclick={this.selectTab.bind(this)}>Project Folders</span>
+                <span class="bart__tabs bart-watch__tab" onclick={this.selectTab.bind(this)}>Files to Watch</span>
+            </div>
             <div class="bart-options-main">
-                <div class='block'>
-                    <label>Credentials for sandbox</label>
-                </div>
-                <div class='block'>
-                    <div class="controls">
-                        <label class="control-label">
-                            HostName
-                        </label>
+                <div class="bart__containers bart__containers--active bart-webdav__container">
+                    <div class='block'>
+                        <label>Credentials for sandbox</label>
+                    </div>
+                    <div class='block'>
                         <div class="controls">
-                            <div class="editor-container">
-                                <atom-text-editor mini="" class="mini editor bart-hostname"
-                                    tabindex="1" id="bart-hostname"
-                                    placeholder-text="some.demandware.net"
-                                />
+                            <label class="control-label">
+                                HostName
+                            </label>
+                            <div class="controls">
+                                <div class="editor-container">
+                                    <atom-text-editor mini="" class="mini editor bart-hostname"
+                                        tabindex="1" id="bart-hostname"
+                                        placeholder-text="some.demandware.net"
+                                    />
+                                </div>
                             </div>
                         </div>
                     </div>
-                </div>
-                <div class='block'>
-                    <div class="controls">
-                        <label class="control-label">
-                            UserName
-                        </label>
+                    <div class='block'>
                         <div class="controls">
-                            <div class="editor-container">
-                                <atom-text-editor mini="" class="mini editor bart-username"
-                                    tabindex="2" id="bart-username"
-                                    placeholder-text="Your username on sandbox"
-                                />
+                            <label class="control-label">
+                                UserName
+                            </label>
+                            <div class="controls">
+                                <div class="editor-container">
+                                    <atom-text-editor mini="" class="mini editor bart-username"
+                                        tabindex="2" id="bart-username"
+                                        placeholder-text="Your username on sandbox"
+                                    />
+                                </div>
                             </div>
                         </div>
                     </div>
-                </div>
-                <div class='block'>
-                    <div class="controls">
-                        <label class="control-label">
-                            Password
-                        </label>
+                    <div class='block'>
                         <div class="controls">
-                            <div class="editor-container">
-                                <input type="password" class="mini editor bart-password"
-                                    tabindex="3" id="bart-password"
-                                    placeholder-text="password"
-                                    onKeyDown={this.handleKeyPress.bind(this)}
-                                />
+                            <label class="control-label">
+                                Password
+                            </label>
+                            <div class="controls">
+                                <div class="editor-container">
+                                    <input type="password" class="mini editor bart-password"
+                                        tabindex="3" id="bart-password"
+                                        placeholder-text="password"
+                                        onKeyDown={this.handleKeyPress.bind(this)}
+                                    />
+                                </div>
                             </div>
                         </div>
                     </div>
-                </div>
-                <div class='block'>
-                    <div class="controls">
-                        <label class="control-label">
-                            Code version
-                        </label>
+                    <div class='block'>
                         <div class="controls">
-                            <div class="editor-container">
-                                <atom-text-editor mini="" class="mini editor bart-version"
-                                    tabindex="4" id="bart-codeversion"
-                                    placeholder-text="Current code version"
-                                />
+                            <label class="control-label">
+                                Code version
+                            </label>
+                            <div class="controls">
+                                <div class="editor-container">
+                                    <atom-text-editor mini="" class="mini editor bart-version"
+                                        tabindex="4" id="bart-codeversion"
+                                        placeholder-text="Current code version"
+                                    />
+                                </div>
                             </div>
                         </div>
                     </div>
-                </div>
-                <div class='block'>
-                    <div class='bart-list-container'>
-                        <label>Cartridges found in project</label>
+
+                    <div class='block'>
                         <div class="control-group">
-                            <button tabindex="5" class="btn bart-btn-all" onClick={this.setAll.bind(this)}>Deselect All</button>
-                        </div>
-                        <div class="cartridgelist-div-list">
-                            <ul tabindex="6" class="cartridgelist-ul">
-                            </ul>
+                            <div class="controls">
+                                <div class="checkbox">
+                                    <label for="bart-uploadaftersave">
+                                        <input id="bart-uploadaftersave"
+                                            tabindex="8"
+                                            type="checkbox"
+                                            checked="checked"
+                                            class="bart-uploadaftersave" />
+                                        <div class="setting-title">Upload all after save</div>
+                                    </label>
+                                </div>
+                            </div>
                         </div>
                     </div>
-                </div>
-                <div class='block'>
-                    <div class="controls">
-                        <label class="control-label">
-                            List of files that should be wathched (separated by new line)
-                        </label>
-                        <div class="controls">
-                            <div class="editor-container">
-                                <atom-text-editor class="mini editor bart-watchlist"
-                                    tabindex="7" id="bart-watchlist"
-                                    placeholder-text="File list (absolute path)"
-                                />
+                    <div class='block'>
+                        <div class="control-group">
+                            <div class="controls">
+                                <div class="checkbox">
+                                    <label for="bart-saveconfigtofile">
+                                        <input id="bart-saveconfigtofile"
+                                            tabindex="9"
+                                            type="checkbox"
+                                            checked="checked"
+                                            class="bart-saveconfigtofile" />
+                                        <div class="setting-title">Save config in root folder (Config file 'dw.json')</div>
+                                    </label>
+                                </div>
                             </div>
                         </div>
                     </div>
                 </div>
-            </div>
-            <div class='block'>
-                <div class="control-group">
-                    <div class="controls">
-                        <div class="checkbox">
-                            <label for="bart-uploadaftersave">
-                                <input id="bart-uploadaftersave"
-                                    tabindex="8"
-                                    type="checkbox"
-                                    checked="checked"
-                                    class="bart-uploadaftersave" />
-                                <div class="setting-title">Upload all after save</div>
-                            </label>
+                <div class="bart__containers bart-cartridges__container">
+                    <div class='block'>
+                        <div class='bart-list-container'>
+                            <label>Cartridges found in project</label>
+                            <div class="control-group">
+                                <button tabindex="5" class="btn bart-btn-all" onClick={this.setAll.bind(this)}>Deselect All</button>
+                            </div>
+                            <div class="cartridgelist-div-list">
+                                <ul tabindex="6" class="cartridgelist-ul">
+                                </ul>
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
-            <div class='block'>
-                <div class="control-group">
-                    <div class="controls">
-                        <div class="checkbox">
-                            <label for="bart-saveconfigtofile">
-                                <input id="bart-saveconfigtofile"
-                                    tabindex="9"
-                                    type="checkbox"
-                                    checked="checked"
-                                    class="bart-saveconfigtofile" />
-                                <div class="setting-title">Save config in root folder (Config file 'dw.json')</div>
+                <div class="bart__containers bart-folders__container">
+
+                </div>
+                <div class="bart__containers bart-watch__container">
+                    <div class='block'>
+                        <div class="controls">
+                            <label class="control-label">
+                                List of files that should be wathched (separated by new line)
                             </label>
+                            <div class="controls">
+                                <div class="editor-container">
+                                    <atom-text-editor class="mini editor bart-watchlist"
+                                        tabindex="7" id="bart-watchlist"
+                                        placeholder-text="File list (absolute path)"
+                                    />
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -253,6 +269,21 @@ export default class OptionsView {
             }
         }
         return false;
+    }
+    selectTab(e) {
+        if (!this.tabs) {
+            this.tabs = this.el.getElementsByClassName('bart__tabs');
+            this.containers = this.el.getElementsByClassName('bart__containers');
+        }
+        if(!e.target.classList.contains('bart__tabs--active')) {
+            for (let x = 0; x < this.tabs.length; x++) {
+                if (this.tabs[x].classList.contains('bart__tabs--active')
+                || this.tabs[x] == e.target) {
+                    this.tabs[x].classList.toggle('bart__tabs--active');
+                    this.containers[x].classList.toggle('bart__containers--active');
+                }
+            }
+        }
     }
     setAll() {
         let cartElements = this.cartridgeList

--- a/lib/OptionsView.js
+++ b/lib/OptionsView.js
@@ -152,6 +152,7 @@ export default class OptionsView {
                              .item(0);
     }
     displayAvailable() {
+        this.isChecked = true;
         if (this.currentOptions.cartridges &&
             this.currentOptions.cartridges.trim().length) {
             this.cartridges.checked = this.currentOptions.cartridges
@@ -240,14 +241,14 @@ export default class OptionsView {
         for (let x = 0; x < cartElements.length; x++) {
             if (cartElements[x].type &&
                 cartElements[x].type.toLowerCase() === 'checkbox') {
-                cartElements[x].checked = this.isChecked;
+                cartElements[x].checked = !this.isChecked;
             }
         }
         this.isChecked = !this.isChecked;
         if (!this.btnAll) {
             this.btnAll = this.el.getElementsByClassName('bart-btn-all');
         }
-        this.btnAll[0].innerHTML = !this.isChecked
+        this.btnAll[0].innerHTML = this.isChecked
                                    ? 'Deselect All' : 'Select All';
     }
     handleKeyPress(e) {

--- a/lib/OptionsView.js
+++ b/lib/OptionsView.js
@@ -59,7 +59,7 @@ export default class OptionsView {
                         </label>
                         <div class="controls">
                             <div class="editor-container">
-                                <input type="password" class="mini editor bart-password"
+                                <input type="password" class="mini editor b-bart_password_input"
                                     tabindex="3" id="bart-password"
                                     placeholder-text="password"
                                     onKeyDown={this.handleKeyPress.bind(this)}

--- a/lib/OptionsView.js
+++ b/lib/OptionsView.js
@@ -4,130 +4,138 @@
 import {domElement as elementCreator} from './elementCreator';
 import EventEmitter from 'events';
 
+const path = require('path'),
+      fs = require('fs');
+
 export default class OptionsView {
     constructor (currentOptions = {}) {
+        this.isChecked = true;
+        this.currentOptions = currentOptions;
         this.emitter = new EventEmitter();
+        this.cartridges = {
+            all: [],
+            checked: []
+        };
         this.el =
         <div class="b-bart-options">
-            <div class='block'>
-                <label>Credentials for sandbox</label>
-            </div>
-            <div class='block'>
-                <div class="controls">
-                    <label class="control-label">
-                        HostName
-                    </label>
+            <div class="bart-options-main">
+                <div class='block'>
+                    <label>Credentials for sandbox</label>
+                </div>
+                <div class='block'>
                     <div class="controls">
-                        <div class="editor-container">
-                            <atom-text-editor mini="" class="mini editor bart-hostname"
-                                tabindex="1" id="bart-hostname"
-                                placeholder-text="some.demandware.net"
-                            />
+                        <label class="control-label">
+                            HostName
+                        </label>
+                        <div class="controls">
+                            <div class="editor-container">
+                                <atom-text-editor mini="" class="mini editor bart-hostname"
+                                    tabindex="1" id="bart-hostname"
+                                    placeholder-text="some.demandware.net"
+                                />
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
-            <div class='block'>
-                <div class="controls">
-                    <label class="control-label">
-                        UserName
-                    </label>
+                <div class='block'>
                     <div class="controls">
-                        <div class="editor-container">
-                            <atom-text-editor mini="" class="mini editor bart-username"
-                                tabindex="2" id="bart-username"
-                                placeholder-text="Your username on sandbox"
-                            />
+                        <label class="control-label">
+                            UserName
+                        </label>
+                        <div class="controls">
+                            <div class="editor-container">
+                                <atom-text-editor mini="" class="mini editor bart-username"
+                                    tabindex="2" id="bart-username"
+                                    placeholder-text="Your username on sandbox"
+                                />
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
-            <div class='block'>
-                <div class="controls">
-                    <label class="control-label">
-                        Password
-                    </label>
+                <div class='block'>
                     <div class="controls">
-                        <div class="editor-container">
-                            <atom-text-editor mini="" class="mini editor bart-password"
-                                tabindex="3" id="bart-password"
-                                placeholder-text="Your password on sandbox"
-                            />
+                        <label class="control-label">
+                            Password
+                        </label>
+                        <div class="controls">
+                            <div class="editor-container">
+                                <input type="password" class="mini editor bart-password"
+                                    tabindex="3" id="bart-password"
+                                    placeholder-text="password"
+                                    onKeyDown={this.handleKeyPress.bind(this)}
+                                />
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
-            <div class='block'>
-                <div class="controls">
-                    <label class="control-label">
-                        Code version
-                    </label>
+                <div class='block'>
                     <div class="controls">
-                        <div class="editor-container">
-                            <atom-text-editor mini="" class="mini editor bart-version"
-                                tabindex="4" id="bart-codeversion"
-                                placeholder-text="Current code version"
-                            />
+                        <label class="control-label">
+                            Code version
+                        </label>
+                        <div class="controls">
+                            <div class="editor-container">
+                                <atom-text-editor mini="" class="mini editor bart-version"
+                                    tabindex="4" id="bart-codeversion"
+                                    placeholder-text="Current code version"
+                                />
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
-            <div class='block'>
-                <div class="controls">
-                    <label class="control-label">
-                        List of cartridges that should be uploaded (all folders will be uploaded if empty)
-                    </label>
-                    <div class="controls">
-                        <div class="editor-container">
-                            <atom-text-editor class="mini editor bart-cartridges"
-                                tabindex="4" id="bart-cartrigges"
-                                placeholder-text="path relative to project folder"
-                            />
+                <div class='block'>
+                    <div class='bart-list-container'>
+                        <label>Cartridges found in project</label>
+                        <div class="control-group">
+                            <button class="btn bart-btn-all" onClick={this.setAll.bind(this)}>Deselect All</button>
+                        </div>
+                        <div class="cartridgelist-div-list">
+                            <ul class="cartridgelist-ul">
+                            </ul>
                         </div>
                     </div>
                 </div>
-            </div>
-            <div class='block'>
-                <div class="controls">
-                    <label class="control-label">
-                        List of files that should be wathched (separated by new line)
-                    </label>
+                <div class='block'>
                     <div class="controls">
-                        <div class="editor-container">
-                            <atom-text-editor class="mini editor bart-watchlist"
-                                tabindex="4" id="bart-watchlist"
-                                placeholder-text="File list (absolute path)"
-                            />
+                        <label class="control-label">
+                            List of files that should be wathched (separated by new line)
+                        </label>
+                        <div class="controls">
+                            <div class="editor-container">
+                                <atom-text-editor class="mini editor bart-watchlist"
+                                    tabindex="4" id="bart-watchlist"
+                                    placeholder-text="File list (absolute path)"
+                                />
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
-            <div class='block'>
-                <div class="control-group">
-                    <div class="controls">
-                        <div class="checkbox">
-                            <label for="bart-uploadaftersave">
-                                <input id="bart-uploadaftersave"
-                                    type="checkbox"
-                                    checked="checked"
-                                    class="bart-uploadaftersave" />
-                                <div class="setting-title">Upload all after save</div>
-                            </label>
+                <div class='block'>
+                    <div class="control-group">
+                        <div class="controls">
+                            <div class="checkbox">
+                                <label for="bart-uploadaftersave">
+                                    <input id="bart-uploadaftersave"
+                                        type="checkbox"
+                                        checked="checked"
+                                        class="bart-uploadaftersave" />
+                                    <div class="setting-title">Upload all after save</div>
+                                </label>
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
-            <div class='block'>
-                <button class="btn" onClick={this.onSave.bind(this)} >Save</button>
-                <button class="btn" onClick={this.onCancel.bind(this)}>Cancel</button>
-                <div class="error-messages js-bart_error" ></div>
+                <div class='block'>
+                    <button class="btn" onClick={this.onSave.bind(this)} >Save</button>
+                    <button class="btn" onClick={this.onCancel.bind(this)}>Cancel</button>
+                    <div class="error-messages js-bart_error" ></div>
+                </div>
             </div>
         </div>;
         [
             'hostname',
             'username',
             'version',
-            'cartridges',
             'watchlist',
             'uploadaftersave'
         ].forEach((key) => {
@@ -140,17 +148,125 @@ export default class OptionsView {
                 }
             }
         });
+        this.cartridgeList = this.el.getElementsByClassName('cartridgelist-ul').item(0);
+    }
+    displayAvailable() {
+        if (this.currentOptions.cartridges && this.currentOptions.cartridges.trim().length) {
+            this.cartridges.checked = this.currentOptions.cartridges.split('\n');
+        } else {
+            this.cartridges.checked = [];
+        }
+        this.cartridges.all = [];
+        this.cartridgeList.innerHTML = '';
+        let dirs = atom.project.getDirectories();
+        if (dirs.length) {
+            dirs.forEach((dir) => {
+                let path = dir.getPath();
+                let name = path.split('/').pop();
+                if (this.isCartridge(dir) &&
+                !this.cartridges.all.includes(name)) {
+                    this.createCartridgeCheckbox(dir, '');
+                } else {
+                    let prs = this.checkDirLevel(dir);
+                }
+            });
+        }
+    }
+    checkDirLevel(dir) {
+        let promise = new Promise((resolve, reject) => {
+            dir.getEntries((err, children) => {
+                if (err) {
+                  this.setError(err);
+                } else {
+                    let parent = dir.getPath().split('/').pop();
+                    children.forEach((child) => {
+                        if (child.isDirectory && this.isCartridge(child)
+                        && !this.cartridges.all.includes(child.getPath()
+                        .split('/').pop())) {
+                            this.createCartridgeCheckbox(child, parent);
+                        }
+                    });
+                }
+            });
+        })
+        .then(() => {
+          this.isSet = true;
+        });
+    }
+    createCartridgeCheckbox (dir, projectDir) {
+        let cPath = dir.getPath().substr(dir.getPath().indexOf(projectDir),
+            (dir.getPath().length - 1));
+        let name = cPath.split('/').pop();
+        let checked = this.cartridges && this.cartridges.checked &&
+            this.cartridges.checked.length &&
+            this.cartridges.checked.includes(name);
+        if (!checked && this.isChecked) {
+            this.isChecked = false;
+            if (!this.btnAll) {
+                this.btnAll = this.el.getElementsByClassName('bart-btn-all');
+            }
+            this.btnAll.innerHTML = 'Select All';
+        }
+        let ele =
+            <li>
+                <div class="bart-cartridgelist-item">
+                    <input type="checkbox"
+                        class="bart-cartridgelist-checkbox"
+                        value={name}
+                        name={name}
+                        id={name}/>
+                    <label for={name}>
+                        {name}
+                    </label>
+                </div>
+            </li>;
+        let inp = ele.getElementsByClassName('bart-cartridgelist-checkbox');
+        inp[0].checked = checked;
+        this.cartridgeList.appendChild(ele);
+        this.cartridges.all.push(name);
+    }
+    isCartridge(dirPath) {
+        const regexPattern = /^[a-zA-Z0-9_]+/;
+        if (dirPath.isDirectory()) {
+            let pathName = dirPath.getPath().split('/').pop();
+            if (regexPattern.test(pathName) && dirPath.getSubdirectory('cartridge').existsSync()) {
+                return true;
+            }
+        }
+        return false;
+    }
+    setAll() {
+        let cartElements = this.cartridgeList.getElementsByClassName('bart-cartridgelist-checkbox');
+        for (let x = 0; x < cartElements.length; x++) {
+            if (cartElements[x].type && cartElements[x].type.toLowerCase() === 'checkbox') {
+                cartElements[x].checked = this.isChecked;
+            }
+        }
+        this.isChecked = !this.isChecked;
+        if (!this.btnAll) {
+            this.btnAll = this.el.getElementsByClassName('bart-btn-all');
+        }
+        this.btnAll[0].innerHTML = !this.isChecked ? 'Deselect All' : 'Select All';
+    }
+    handleKeyPress(e) {
+      if (e.code === 'Backspace') {
+          e.target.value = e.target.value.substr(0, e.target.value.length - 1);
+      }
     }
     setError (msg = '') {
         const div = this.el.getElementsByClassName('js-bart_error');
         if (div && div.length) {
             div[0].textContent = msg;
+            if (msg !== '') {
+                div[0].scrollIntoView();
+            }
         }
+
     }
     clean () {
         const div = this.el.getElementsByClassName('bart-password');
         if (div && div.length) {
-            div[0].getModel().setText('');
+            div[0].value = '';
         }
     }
     on (name, fn) {
@@ -169,17 +285,32 @@ export default class OptionsView {
             'cartridges',
             'uploadaftersave'
         ].reduce((acc, elemClass) => {
-            const div = this.el.getElementsByClassName('bart-' + elemClass);
-            if (div && div.length) {
-                if (div[0].type === 'checkbox') {
-                    acc[elemClass] = div[0].checked;
-                } else {
-                    acc[elemClass] = div[0].getModel().getText() || '';
+            if (elemClass === 'cartridges') {
+              let cartElements = this.cartridgeList
+                  .getElementsByClassName('bart-cartridgelist-checkbox');
+              acc['cartridges'] = '';
+              for (let x = 0; x < cartElements.length; x++) {
+                  if (cartElements[x].type && cartElements[x].type === 'checkbox'
+                  && cartElements[x].checked) {
+                    acc['cartridges'] += cartElements[x].value + '\n';
+                  }
+              }
+            } else {
+                const div = this.el.getElementsByClassName('bart-' + elemClass);
+                if (div && div.length) {
+                    if (div[0].type === 'checkbox') {
+                        acc[elemClass] = div[0].checked;
+                    } else if (div[0].type === 'password') {
+                        acc[elemClass] = div[0].value;
+                    } else {
+                        acc[elemClass] = div[0].getModel().getText() || '';
+                    }
                 }
             }
             return acc;
         }, {});
         this.emitter.emit('save', config);
+        this.currentOptions = config;
     }
     onCancel () {
         this.emitter.emit('cancel');

--- a/lib/OptionsView.js
+++ b/lib/OptionsView.js
@@ -170,14 +170,14 @@ export default class OptionsView {
             }
         });
         this.cartridgeList = this.el.getElementsByClassName('cartridgelist-ul')
-                             .item(0);
+            .item(0);
+        this.btnAll = this.el.getElementsByClassName('bart-btn-all');
     }
     displayAvailable() {
         this.isChecked = true;
         if (this.currentOptions.cartridges &&
-            this.currentOptions.cartridges.trim().length) {
-            this.cartridges.checked = this.currentOptions.cartridges
-                                      .split('\n');
+            this.currentOptions.cartridges.length) {
+            this.cartridges.checked = this.currentOptions.cartridges;
         } else {
             this.cartridges.checked = [];
         }
@@ -216,15 +216,13 @@ export default class OptionsView {
         });
     }
     createCartridgeCheckbox (dir, projectDir) {
-        let name = projectDir + dir.getPath().split(path.sep).pop();
+        let displayName = projectDir + dir.getPath().split(path.sep).pop();
+        let name = path.sep + displayName;
         let checked = this.cartridges && this.cartridges.checked &&
                       this.cartridges.checked.length &&
                       this.cartridges.checked.includes(name);
         if (!checked && this.isChecked) {
             this.isChecked = false;
-            if (!this.btnAll) {
-                this.btnAll = this.el.getElementsByClassName('bart-btn-all');
-            }
             this.btnAll.innerHTML = 'Select All';
         }
         let ele =
@@ -236,7 +234,7 @@ export default class OptionsView {
                         name={name}
                         id={name}/>
                     <label for={name}>
-                        {name}
+                        {displayName}
                     </label>
                 </div>
             </li>;
@@ -266,9 +264,6 @@ export default class OptionsView {
             }
         }
         this.isChecked = !this.isChecked;
-        if (!this.btnAll) {
-            this.btnAll = this.el.getElementsByClassName('bart-btn-all');
-        }
         this.btnAll[0].innerHTML = this.isChecked
                                    ? 'Deselect All' : 'Select All';
     }
@@ -310,15 +305,15 @@ export default class OptionsView {
             'saveconfigtofile'
         ].reduce((acc, elemClass) => {
             if (elemClass === 'cartridges') {
-              let cartElements = this.cartridgeList
-              .getElementsByClassName('bart-cartridgelist-checkbox');
-              acc['cartridges'] = '';
-              for (let x = 0; x < cartElements.length; x++) {
-                  if (cartElements[x].type && cartElements[x].type === 'checkbox'
-                  && cartElements[x].checked) {
-                      acc['cartridges'] += cartElements[x].value + '\n';
-                  }
-              }
+                let cartElements = this.cartridgeList
+                .getElementsByClassName('bart-cartridgelist-checkbox');
+                acc['cartridges'] = [];
+                for (let x = 0; x < cartElements.length; x++) {
+                    if (cartElements[x].type && cartElements[x].type === 'checkbox'
+                    && cartElements[x].checked) {
+                        acc['cartridges'].push(cartElements[x].value);
+                    }
+                }
             } else {
                 const div = this.el.getElementsByClassName('bart-' + elemClass);
                 if (div && div.length) {

--- a/lib/OptionsView.js
+++ b/lib/OptionsView.js
@@ -59,7 +59,7 @@ export default class OptionsView {
                         </label>
                         <div class="controls">
                             <div class="editor-container">
-                                <input type="password" class="mini editor b-bart_password_input"
+                                <input type="password" class="mini editor bart-password"
                                     tabindex="3" id="bart-password"
                                     placeholder-text="password"
                                     onKeyDown={this.handleKeyPress.bind(this)}
@@ -152,6 +152,7 @@ export default class OptionsView {
         [
             'hostname',
             'username',
+            'password',
             'version',
             'watchlist',
             'uploadaftersave',
@@ -161,6 +162,8 @@ export default class OptionsView {
             if (div && div.length) {
                 if (div[0].type === 'checkbox') {
                     div[0].checked = currentOptions[key] === 'true';
+                } else if (div[0].type === 'password') {
+                    div[0].value = currentOptions[key];
                 } else {
                     div[0].getModel().setText(currentOptions[key] || '');
                 }

--- a/lib/OptionsView.js
+++ b/lib/OptionsView.js
@@ -87,10 +87,10 @@ export default class OptionsView {
                     <div class='bart-list-container'>
                         <label>Cartridges found in project</label>
                         <div class="control-group">
-                            <button class="btn bart-btn-all" onClick={this.setAll.bind(this)}>Deselect All</button>
+                            <button tabindex="5" class="btn bart-btn-all" onClick={this.setAll.bind(this)}>Deselect All</button>
                         </div>
                         <div class="cartridgelist-div-list">
-                            <ul class="cartridgelist-ul">
+                            <ul tabindex="6" class="cartridgelist-ul">
                             </ul>
                         </div>
                     </div>
@@ -103,7 +103,7 @@ export default class OptionsView {
                         <div class="controls">
                             <div class="editor-container">
                                 <atom-text-editor class="mini editor bart-watchlist"
-                                    tabindex="4" id="bart-watchlist"
+                                    tabindex="7" id="bart-watchlist"
                                     placeholder-text="File list (absolute path)"
                                 />
                             </div>
@@ -117,6 +117,7 @@ export default class OptionsView {
                         <div class="checkbox">
                             <label for="bart-uploadaftersave">
                                 <input id="bart-uploadaftersave"
+                                    tabindex="8"
                                     type="checkbox"
                                     checked="checked"
                                     class="bart-uploadaftersave" />
@@ -132,6 +133,7 @@ export default class OptionsView {
                         <div class="checkbox">
                             <label for="bart-saveconfigtofile">
                                 <input id="bart-saveconfigtofile"
+                                    tabindex="9"
                                     type="checkbox"
                                     checked="checked"
                                     class="bart-saveconfigtofile" />

--- a/lib/OptionsView.js
+++ b/lib/OptionsView.js
@@ -148,11 +148,14 @@ export default class OptionsView {
                 }
             }
         });
-        this.cartridgeList = this.el.getElementsByClassName('cartridgelist-ul').item(0);
+        this.cartridgeList = this.el.getElementsByClassName('cartridgelist-ul')
+                             .item(0);
     }
     displayAvailable() {
-        if (this.currentOptions.cartridges && this.currentOptions.cartridges.trim().length) {
-            this.cartridges.checked = this.currentOptions.cartridges.split('\n');
+        if (this.currentOptions.cartridges &&
+            this.currentOptions.cartridges.trim().length) {
+            this.cartridges.checked = this.currentOptions.cartridges
+                                      .split('\n');
         } else {
             this.cartridges.checked = [];
         }
@@ -173,33 +176,28 @@ export default class OptionsView {
         }
     }
     checkDirLevel(dir) {
-        let promise = new Promise((resolve, reject) => {
-            dir.getEntries((err, children) => {
-                if (err) {
-                  this.setError(err);
-                } else {
-                    let parent = dir.getPath().split('/').pop();
-                    children.forEach((child) => {
-                        if (child.isDirectory && this.isCartridge(child)
+        dir.getEntries((err, children) => {
+            if (err) {
+                this.setError(err);
+            } else {
+                let parent = dir.getPath().split('/').pop();
+                children.forEach((child) => {
+                    if (child.isDirectory && this.isCartridge(child)
                         && !this.cartridges.all.includes(child.getPath()
                         .split('/').pop())) {
-                            this.createCartridgeCheckbox(child, parent);
-                        }
-                    });
-                }
-            });
-        })
-        .then(() => {
-          this.isSet = true;
+                        this.createCartridgeCheckbox(child, parent);
+                    }
+                });
+            }
         });
     }
     createCartridgeCheckbox (dir, projectDir) {
         let cPath = dir.getPath().substr(dir.getPath().indexOf(projectDir),
-            (dir.getPath().length - 1));
+                    (dir.getPath().length - 1));
         let name = cPath.split('/').pop();
         let checked = this.cartridges && this.cartridges.checked &&
-            this.cartridges.checked.length &&
-            this.cartridges.checked.includes(name);
+                      this.cartridges.checked.length &&
+                      this.cartridges.checked.includes(name);
         if (!checked && this.isChecked) {
             this.isChecked = false;
             if (!this.btnAll) {
@@ -229,16 +227,19 @@ export default class OptionsView {
         const regexPattern = /^[a-zA-Z0-9_]+/;
         if (dirPath.isDirectory()) {
             let pathName = dirPath.getPath().split('/').pop();
-            if (regexPattern.test(pathName) && dirPath.getSubdirectory('cartridge').existsSync()) {
+            if (regexPattern.test(pathName) && dirPath
+                .getSubdirectory('cartridge').existsSync()) {
                 return true;
             }
         }
         return false;
     }
     setAll() {
-        let cartElements = this.cartridgeList.getElementsByClassName('bart-cartridgelist-checkbox');
+        let cartElements = this.cartridgeList
+                           .getElementsByClassName('bart-cartridgelist-checkbox');
         for (let x = 0; x < cartElements.length; x++) {
-            if (cartElements[x].type && cartElements[x].type.toLowerCase() === 'checkbox') {
+            if (cartElements[x].type &&
+                cartElements[x].type.toLowerCase() === 'checkbox') {
                 cartElements[x].checked = this.isChecked;
             }
         }
@@ -246,7 +247,8 @@ export default class OptionsView {
         if (!this.btnAll) {
             this.btnAll = this.el.getElementsByClassName('bart-btn-all');
         }
-        this.btnAll[0].innerHTML = !this.isChecked ? 'Deselect All' : 'Select All';
+        this.btnAll[0].innerHTML = !this.isChecked
+                                   ? 'Deselect All' : 'Select All';
     }
     handleKeyPress(e) {
       if (e.code === 'Backspace') {
@@ -261,7 +263,6 @@ export default class OptionsView {
                 div[0].scrollIntoView();
             }
         }
-
     }
     clean () {
         const div = this.el.getElementsByClassName('bart-password');
@@ -287,12 +288,12 @@ export default class OptionsView {
         ].reduce((acc, elemClass) => {
             if (elemClass === 'cartridges') {
               let cartElements = this.cartridgeList
-                  .getElementsByClassName('bart-cartridgelist-checkbox');
+              .getElementsByClassName('bart-cartridgelist-checkbox');
               acc['cartridges'] = '';
               for (let x = 0; x < cartElements.length; x++) {
                   if (cartElements[x].type && cartElements[x].type === 'checkbox'
                   && cartElements[x].checked) {
-                    acc['cartridges'] += cartElements[x].value + '\n';
+                      acc['cartridges'] += cartElements[x].value + '\n';
                   }
               }
             } else {

--- a/lib/OptionsView.js
+++ b/lib/OptionsView.js
@@ -223,7 +223,7 @@ export default class OptionsView {
                       this.cartridges.checked.includes(name);
         if (!checked && this.isChecked) {
             this.isChecked = false;
-            this.btnAll.innerHTML = 'Select All';
+            this.btnAll[0].innerHTML = 'Select All';
         }
         let ele =
             <li>

--- a/lib/OptionsView.js
+++ b/lib/OptionsView.js
@@ -187,7 +187,7 @@ export default class OptionsView {
                 !this.cartridges.all.includes(name)) {
                     this.createCartridgeCheckbox(dir, '');
                 } else {
-                    this.checkChildDirectory(dir);
+                    this.checkChildDirectory(dir, '');
                 }
             });
         }
@@ -200,10 +200,10 @@ export default class OptionsView {
             } else {
                 children.forEach((child) => {
                     let name = child.getPath().split(path.sep).pop();
-                    if (child.isDirectory && this.isCartridge(child)
+                    if (child.isDirectory() && this.isCartridge(child)
                         && !this.cartridges.all.includes(rpath + name)) {
                         this.createCartridgeCheckbox(child, rpath);
-                    } else if (child.isDirectory && !this.isCartridge(child)) {
+                    } else if (child.isDirectory() && !this.isCartridge(child)) {
                         this.checkChildDirectory(child, rpath + name);
                     }
                 });

--- a/lib/OptionsView.js
+++ b/lib/OptionsView.js
@@ -192,28 +192,26 @@ export default class OptionsView {
             });
         }
     }
-    checkChildDirectory(dir, parent) {
+    checkChildDirectory(dir, relativePath) {
+        let rpath = !relativePath ? '' : relativePath + path.sep;
         dir.getEntries((err, children) => {
             if (err) {
                 this.setError(err);
             } else {
-                let parentDir = !parent ? dir.getPath().split(path.sep).pop() :
-                    parent;
                 children.forEach((child) => {
+                    let name = child.getPath().split(path.sep).pop();
                     if (child.isDirectory && this.isCartridge(child)
-                        && !this.cartridges.all.includes(child.getPath()
-                        .split(path.sep).pop())) {
-                        this.createCartridgeCheckbox(child, parentDir);
+                        && !this.cartridges.all.includes(rpath + name)) {
+                        this.createCartridgeCheckbox(child, rpath);
                     } else if (child.isDirectory && !this.isCartridge(child)) {
-                        checkChildDirectory(child, parentDir);
+                        this.checkChildDirectory(child, rpath + name);
                     }
                 });
             }
         });
     }
     createCartridgeCheckbox (dir, projectDir) {
-        let name = dir.getPath().substr(dir.getPath().indexOf(projectDir),
-                    (dir.getPath().length - 1)).split(path.sep).pop();
+        let name = projectDir + dir.getPath().split(path.sep).pop();
         let checked = this.cartridges && this.cartridges.checked &&
                       this.cartridges.checked.length &&
                       this.cartridges.checked.includes(name);

--- a/lib/bart.js
+++ b/lib/bart.js
@@ -188,7 +188,6 @@ const Bart = {
                 this.optionsView.setError('Code version must not be empty');
             }
         });
-
         this.newCartridgeView = new NewCartridgeView();
         this.newCartridgePanel = atom.workspace.addModalPanel({
             item : this.newCartridgeView.getElement(),
@@ -288,8 +287,6 @@ const Bart = {
                 return webdav.uploadCartridges(dir.getPath(), notify);
             }
         });
-
-
         Promise.all(paths).then(() => {
             console.log('success');
             this.progressPanel.hide();
@@ -304,6 +301,7 @@ const Bart = {
             this.optionsPanel.hide();
         } else {
             this.optionsPanel.show();
+            this.optionsView.displayAvailable();
         }
     },
     toggleDebugger: () => {

--- a/lib/bart.js
+++ b/lib/bart.js
@@ -115,7 +115,7 @@ const Bart = {
             Bart.setConfigToFile(options);
             return;
         }
-        
+
         Object.keys(options).forEach((key) => {
             if (key === 'password') {
                 sessionStorage['bart-' + key] = options[key];
@@ -126,7 +126,7 @@ const Bart = {
     },
     getOptions : () => {
         var configObj = Bart.getConfigFromFile();
-        
+
         if (!configObj) {
             configObj = [
                 'password',
@@ -153,7 +153,7 @@ const Bart = {
         const fileName = 'dw.json',
             getPaths = atom.project.getPaths();
         var configFilePath = '';
-        
+
         configFilePath = (getPaths[0] ? getPaths[0] : './');
         return configFilePath + (~configFilePath.indexOf('/') ? '/' : '\\') + fileName;
     },
@@ -168,7 +168,7 @@ const Bart = {
                 console.warn('Parse dw.json error: ' + e);
             }
         }
-        
+
         if (confObject) {
             Object.keys(confObject).forEach((key) => {
                 if (confObject[key] === true) {
@@ -182,7 +182,7 @@ const Bart = {
     setConfigToFile : (options) => {
         const configFilePath = Bart.getConfigFilePath();
         var configJson = JSON.stringify(options) || '';
-        
+
         fs.writeFileSync(configFilePath, configJson);
     },
     activate : () => {
@@ -221,14 +221,14 @@ const Bart = {
         });
         this.optionsView.on('save', (options) => {
             const WebDav = require('./webdav');
-            
+
             if (!options.password) {
                 const storedOptions = Bart.getConfigFromFile();
                 if (storedOptions && storedOptions.password) {
                     options.password = storedOptions.password;
                 }
             }
-            
+
             const webdav = new WebDav(options);
 
             if (options.version) {

--- a/lib/bart.js
+++ b/lib/bart.js
@@ -36,9 +36,8 @@ const path2DwPath = (fileName) => {
         return
     }
 
-    if (options.cartridges && options.cartridges.trim().length) {
+    if (options.cartridges && options.cartridges.length) {
         let cartPath = options.cartridges
-            .split('\n')
             .map(str => str.trim())
             .find((path) => fileName.indexOf(path) !== -1);
 
@@ -334,9 +333,8 @@ const Bart = {
             this.progressMsg.setMessage(msg);
         }
         const paths = atom.project.getDirectories().map((dir) => {
-            if (options.cartridges && options.cartridges.trim().length) {
+            if (options.cartridges && options.cartridges.length) {
                 return options.cartridges
-                    .split('\n')
                     .map(str => str.trim())
                     .reduce( (promise, cartridge) => {
                         return promise.then(() => {

--- a/styles/bart.less
+++ b/styles/bart.less
@@ -12,7 +12,7 @@
 }
 .b-bart-options {
     max-height: 600px;
-    overflow-y: auto;
+    overflow-y: hidden;
 }
 
 .b-bart_variables {
@@ -28,15 +28,47 @@
     padding-left: 15px;
 }
 .bart-password {
-  font-size: 1.15em;
-  line-height: 2em;
-  border-radius: 3px;
-  color: @text-color;
-  border: 1px solid @input-border-color;
-  background-color: @input-background-color;
-  width: 100%;
+    font-size: 1.15em;
+    line-height: 2em;
+    border-radius: 3px;
+    color: @text-color;
+    border: 1px solid @input-border-color;
+    background-color: @input-background-color;
+    width: 100%;
 }
-
+.bart-tabscontainer {
+    border-bottom: 5px solid;;
+    padding-top: 7px;
+    padding-bottom: 7px;
+    height:40px;
+}
+.bart__tabs {
+    position: relative;
+    background-color: @tab-background-color;
+    border: solid 2px @tab-border-color;
+    border-top-left-radius: 5px;
+    border-top-right-radius: 5px;
+    margin: 5px 0 0 0;
+    max-width: 25%;
+    height: auto;
+    padding: 7px;
+    cursor: default;
+    &--active {
+        background-color: @tab-background-color-active;
+        border-color: @button-background-color-selected;
+    }
+}
+.bart__containers {
+    max-height: 525px;
+    overflow-y: scroll;
+    width: 100%;
+    display: none;
+    margin-bottom: 5px;
+    border-bottom: 5px solid;
+    &--active {
+        display: block;
+    }
+}
 
 
 atom-text-editor::shadow {

--- a/styles/bart.less
+++ b/styles/bart.less
@@ -27,7 +27,17 @@
 .bart_pad_tree {
     padding-left: 15px;
 }
-
+.bart-password {
+  font-size: 1.15em;
+  line-height: 2em;
+  max-height: none;
+  padding-left: 0.5em;
+  border-radius: 3px;
+  color: #d7dae0;
+  border: 1px solid #181a1f;
+  background-color: #1b1d23;
+  width: 100%;
+}
 
 
 

--- a/styles/bart.less
+++ b/styles/bart.less
@@ -27,7 +27,7 @@
 .bart_pad_tree {
     padding-left: 15px;
 }
-.b-bart_password_input {
+.bart-password {
   font-size: 1.15em;
   line-height: 2em;
   border-radius: 3px;

--- a/styles/bart.less
+++ b/styles/bart.less
@@ -27,16 +27,14 @@
 .bart_pad_tree {
     padding-left: 15px;
 }
-.bart-password {
+.b-bart_password_input {
   font-size: 1.15em;
   line-height: 2em;
   border-radius: 3px;
-  box-sizing: border-box;
   color: @text-color;
   border: 1px solid @input-border-color;
   background-color: @input-background-color;
   width: 100%;
-  white-space: pre;
 }
 
 


### PR DESCRIPTION
- Removed the atom-text-editor for entering cartridges and added checkboxes for any cartridges that are found in the project folders.  This is done by checking if the name matches the required naming scheme for a cartridge and checking to see if the cartridge sub-directory exists. If the cartridge is found in the saved current options, then it is selected for the user. This only searches the project directories, and their immediate children directories to keep performance in mind.
- Replaced the atom-text-editor for the password field with an HTML input field type=password in order to mask the password as you type it in.
- Set the options view to scroll to the error display div when an error is displayed so that it is immediately apparent what the issue is when a user is unable to save any updates to the options.

If the pull request for the 'save credentials' functionality is merged, I will pull it into my fork to fix merge issues, and then resubmit.